### PR TITLE
some work on bulkheading the streams

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ log = "0.4"
 mio = "0.6"
 pin-project = "0.4"
 pcap-sys = "0.1"
-tokio = { version = "0.2", features = ["blocking", "io-driver", "rt-threaded", "time"] }
+tokio = { version = "0.2.19", features = ["blocking", "io-driver", "rt-threaded", "time"] }
 
 [dev-dependencies]
 rand = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ log = "0.4"
 mio = "0.6"
 pin-project = "0.4"
 pcap-sys = "0.1"
-tokio = {git = "https://github.com/dbcfd/tokio.git", branch = "poll-evented-error-2413", features = ["blocking", "io-driver", "rt-threaded", "time"] }
+tokio = {git = "https://github.com/dbcfd/tokio.git", branch = "poll-evented-error-2413", commit="8580e1a747854993c0d0be5a8143333b0600865a", features = ["blocking", "io-driver", "rt-threaded", "time"] }
 
 [dev-dependencies]
 rand = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ log = "0.4"
 mio = "0.6"
 pin-project = "0.4"
 pcap-sys = "0.1"
-tokio = {git = "https://github.com/dbcfd/tokio.git", branch = "poll-evented-error-2413", commit="8580e1a747854993c0d0be5a8143333b0600865a", features = ["blocking", "io-driver", "rt-threaded", "time"] }
+tokio = { version = "0.2", features = ["blocking", "io-driver", "rt-threaded", "time"] }
 
 [dev-dependencies]
 rand = "0.3"
@@ -43,5 +43,5 @@ path = "benches/bench_capture.rs"
 name = "bench_capture"
 harness = false
 
-#[patch.crates-io]
-#tokio = { git = "https://github.com/dbcfd/tokio.git", branch = "poll-evented-error-2413" }
+[patch.crates-io]
+tokio = { git = "https://github.com/dbcfd/tokio.git", branch = "poll-evented-error-2413" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ log = "0.4"
 mio = "0.6"
 pin-project = "0.4"
 pcap-sys = "0.1"
-tokio = { version = "0.2.19", features = ["blocking", "io-driver", "rt-threaded", "time"] }
+tokio = {git = "https://github.com/dbcfd/tokio.git", branch = "poll-evented-error-2413", features = ["blocking", "io-driver", "rt-threaded", "time"] }
 
 [dev-dependencies]
 rand = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,5 +43,5 @@ path = "benches/bench_capture.rs"
 name = "bench_capture"
 harness = false
 
-[patch.crates-io]
-tokio = { git = "https://github.com/dbcfd/tokio.git", branch = "poll-evented-error-2413" }
+#[patch.crates-io]
+#tokio = { git = "https://github.com/dbcfd/tokio.git", branch = "poll-evented-error-2413" }

--- a/src/bridge_stream.rs
+++ b/src/bridge_stream.rs
@@ -44,12 +44,16 @@ impl<E: Fail + Sync + Send, T: Stream<Item = StreamItem<E>> + Sized + Unpin> Fut
             let polled = Pin::new(&mut stream).poll_next(cx);
             match polled {
                 Poll::Pending => {
+                    trace!("Callbak gets a pending");
+                    std::mem::replace(this.stream, Some(stream));
                     return Poll::Pending;
                 },
                 Poll::Ready(Some(t)) => {
+                    trace!("Callbak gets a result");
                     return Poll::Ready((idx, Some((stream, t))));
                 }
                 _ => {
+                    trace!("Callbak gets a None");
                     return Poll::Ready((idx, None));
                 }
             }

--- a/src/bridge_stream.rs
+++ b/src/bridge_stream.rs
@@ -23,6 +23,9 @@ use crate::packet::Packet;
 use crate::pcap_util;
 use crate::stream::StreamItem;
 
+
+
+
 #[pin_project]
 struct CallbackFuture<E, T> where
     E: Fail + Sync + Send,
@@ -88,6 +91,11 @@ impl<E: Fail + Sync + Send, T: Stream<Item = StreamItem<E>> + Sized + Unpin>
         }
     }
 }
+
+// The BridgeStream attempts to time order packets from downstream.
+// It does this by collecting a `min_states_needed` amount of packet batches, and then sorting them.
+// We also allow `max_buffer_time` to act as a fallback in case we have 1 slow stream and one fast stream.
+// `max_buffer_time` will check the spread of packets, and if it to large it will sort what it has and pass it on.
 
 #[pin_project]
 pub struct BridgeStream<E: Fail + Sync + Send, T>

--- a/src/bridge_stream.rs
+++ b/src/bridge_stream.rs
@@ -86,7 +86,14 @@ impl<E: Fail + Sync + Send, T: Stream<Item = StreamItem<E>> + Sized + Unpin>
         let max = self.current.last().map(|s| s.last()).flatten();
 
         match (min, max) {
-            (Some(min), Some(max)) => max.timestamp().duration_since(*min.timestamp()).unwrap(),
+            (Some(min), Some(max)) => {
+                let since = max.timestamp().duration_since(*min.timestamp());
+                if let Ok(since) = since {
+                    return since
+                } else {
+                    Duration::from_millis(0)
+                }
+            },
             _ => Duration::from_millis(0),
         }
     }

--- a/src/bridge_stream.rs
+++ b/src/bridge_stream.rs
@@ -184,59 +184,54 @@ impl<E: Fail + Sync + Send, T: Stream<Item = StreamItem<E>> + Sized + Unpin> Str
         let mut max_time_spread: Duration = Duration::from_millis(0);
         let mut not_pending: usize = 0;
         let mut poll_queue: &mut FuturesUnordered<CallbackFuture<E, T>> = this.poll_queue;
-        //loop {
-            loop {
-                match Pin::new(&mut poll_queue).poll_next(cx) {
-                    Poll::Ready(Some((idx, Some((stream, Err(err)))))) => {
-                        trace!("got a error, passing upstream");
-                        return Poll::Ready(Some(Err(err)));
-                    },
-                    Poll::Ready(Some((idx, Some((stream, Ok(item)))))) => {
-                        //type Output = (usize, Option<(T, StreamItem<E>)>);
-                        trace!("Got Ready");
-                        not_pending += 1;
-                        if let Some(state) = states.get_mut(idx) {
-                            trace!("Appending results");
-                            max_time_spread = state.spread().max(max_time_spread);
-                            state.stream = Some(stream);
-                            state.current.push(item);
-                        }
-                    },
-                    Poll::Ready(Some((idx, None))) => {
-                        if let Some(state) = states.get_mut(idx) {
-                            trace!("Interface {} has completed", idx);
-                            state.complete = true;
-                            continue;
-                        }
-                    },
-                    Poll::Pending => {
-                        trace!("Got Pending");
-                        break;
-                    },
-                    Poll::Ready(None) => {
-                        trace!("Reached the end.");
-                        break;
+
+        loop {
+            match Pin::new(&mut poll_queue).poll_next(cx) {
+                Poll::Ready(Some((idx, Some((stream, Err(err)))))) => {
+                    trace!("got a error, passing upstream");
+                    return Poll::Ready(Some(Err(err)));
+                },
+                Poll::Ready(Some((idx, Some((stream, Ok(item)))))) => {
+                    //When the future gives us a result we are given a index, that we use to locate an existing State, and re-add the stream.
+                    trace!("Got Ready");
+                    not_pending += 1;
+                    if let Some(state) = states.get_mut(idx) {
+                        trace!("Appending results");
+                        max_time_spread = state.spread().max(max_time_spread);
+                        state.stream = Some(stream);
+                        state.current.push(item);
                     }
+                },
+                Poll::Ready(Some((idx, None))) => {
+                    if let Some(state) = states.get_mut(idx) {
+                        trace!("Interface {} has completed", idx);
+                        state.complete = true;
+                        continue;
+                    }
+                },
+                Poll::Pending => {
+                    trace!("Got Pending");
+                    break;
+                },
+                Poll::Ready(None) => {
+                    trace!("Reached the end.");
+                    break;
                 }
             }
+        }
 
-            //let mut readded = false;
-
-            for (idx, state) in states.iter_mut().enumerate() {
-                if let Some(stream) = state.stream.take() {
-                    //readded = true;
-                    trace!("re-adding stream to poll queue {}", idx);
-                    let f = CallbackFuture {
-                        idx,
-                        stream: Some(stream),
-                    };
-                    poll_queue.push(f);
-                }
+        for (idx, state) in states.iter_mut().enumerate() {
+            if let Some(stream) = state.stream.take() {
+                //readded = true;
+                trace!("re-adding stream to poll queue {}", idx);
+                let f = CallbackFuture {
+                    idx,
+                    stream: Some(stream),
+                };
+                poll_queue.push(f);
             }
-            // if !readded {
-            //     break;
-            // }
-        //}
+        }
+
         let one_buffer_is_over = max_time_spread > *max_buffer_time;
 
         let ready_count = states
@@ -252,7 +247,7 @@ impl<E: Fail + Sync + Send, T: Stream<Item = StreamItem<E>> + Sized + Unpin> Str
             trace!("Not reporting {} {}", enough_state, one_buffer_is_over);
             vec![]
         };
-
+        //TODO remove since it will wreck ordering
         states.retain(|iface| {
             //drop the complete interfaces
             return !iface.is_complete();

--- a/src/packet/future.rs
+++ b/src/packet/future.rs
@@ -9,7 +9,6 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 use std::time::{Duration, Instant};
 use tokio::task;
-use futures::ready;
 
 extern "C" fn dispatch_callback(
     user: *mut u8,

--- a/src/packet/future.rs
+++ b/src/packet/future.rs
@@ -48,6 +48,7 @@ struct DispatchArgs {
 
 impl DispatchArgs {
     async fn poll(&self, timeout: Option<Duration>) -> Result<(), Error> {
+        trace!("Polling FD with timeout {:?}", timeout);
         let ev = mio::unix::EventedFd(&self.fd);
         let ready = mio::Ready::from_usize(
             mio::Ready::readable().as_usize()
@@ -64,6 +65,7 @@ impl DispatchArgs {
         } else {
             f.await?;
         }
+        trace!("Polling FD done");
         Ok(())
     }
 }
@@ -107,6 +109,7 @@ async fn dispatch(args: DispatchArgs) -> Result<DispatchResult, Error> {
     };
 
     while !args.pcap_handle.interrupted() {
+        trace!("Calling pcap_dispatch.");
         let ret_code = unsafe {
             pcap_sys::pcap_dispatch(
                 args.pcap_handle.as_mut_ptr(),

--- a/src/packet/future.rs
+++ b/src/packet/future.rs
@@ -9,6 +9,7 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 use std::time::{Duration, Instant};
 use tokio::task;
+use futures::ready;
 
 extern "C" fn dispatch_callback(
     user: *mut u8,

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -76,6 +76,7 @@ impl Stream for PacketStream {
 
         match Pin::new(&mut f).poll(cx) {
             Poll::Pending => {
+                trace!("returning pending.");
                 *this.pending = Some(f);
                 Poll::Pending
             }

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -30,13 +30,12 @@ impl PacketStream {
         let live_capture = handle.is_live_capture();
 
         if live_capture {
-            handle
+            let h =handle
                 .set_snaplen(config.snaplen())?
-                .set_non_block()?
                 .set_promiscuous()?
-                .set_timeout(&std::time::Duration::from_secs(0))?
                 .set_buffer_size(config.buffer_size())?
                 .activate()?;
+            h.set_non_block()?;
 
             if let Some(bpf) = config.bpf() {
                 let bpf = handle.compile_bpf(bpf)?;

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -76,7 +76,6 @@ impl Stream for PacketStream {
 
         match Pin::new(&mut f).poll(cx) {
             Poll::Pending => {
-                trace!("returning pending.");
                 *this.pending = Some(f);
                 Poll::Pending
             }


### PR DESCRIPTION
Found out that in cases where we have a fast iface and a very slow iface, bridge stream was dropping packets. This is because the task context was being passed down to the packet future, which will sleep the task if it has no packets, only to be woken up when the OS notifies it of new packets. The fix for this was to add all poll_next() for downstream into a FuturesUnordered structure.  This structure works similar to the select! macro, but is mutable, and allows for inserts and what not (arbitrary length). The FuturesUnordered will pass down its own Waker so that the caller of poll_next (bridge stream) won't block, and will only get result once the downstream is woken up. This seems to have addressed the issue, and ordering seems to be fine.