### PR TITLE
Builder Api

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ First, add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-pcap-async = "0.3"
+pcap-async = "0.5"
 ```
 
 Next, add this to your crate:
@@ -32,17 +32,17 @@ Next, add this to your crate:
 ```rust
 use futures::StreamExt;
 use pcap_async::{Config, Handle, PacketStream};
+use std::convert::TryFrom;
 
 fn main() {
     smol::run(async move {
-        let handle = Handle::lookup().expect("No handle created");
-        let mut provider = PacketStream::new(Config::default(), handle)
-            .expect("Could not create provider")
-            .fuse();
+        let cfg = Config::default();
+        let mut provider = PacketStream::try_from(cfg)
+            .expect("Could not create provider");
         while let Some(packets) = provider.next().await {
     
         }
-        handle.interrupt();
+        provider.interrupt();
     })
 }
 ```

--- a/src/config.rs
+++ b/src/config.rs
@@ -19,6 +19,7 @@ pub struct Config {
     bpf: Option<String>,
     buffer_for: std::time::Duration,
     blocking: bool,
+    rfmon: bool,
 }
 
 impl Config {
@@ -93,6 +94,15 @@ impl Config {
         self.blocking = blocking;
         self
     }
+
+    pub fn rfmon(&self) -> bool {
+        self.rfmon
+    }
+
+    pub fn with_rfmon(&mut self, rfmon: bool) -> &mut Self {
+        self.rfmon = rfmon;
+        self
+    }
 }
 
 impl Default for Config {
@@ -106,6 +116,7 @@ impl Default for Config {
             bpf: None,
             buffer_for: std::time::Duration::from_millis(100),
             blocking: false,
+            rfmon: false,
         }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,16 +1,36 @@
 use std;
+use std::path::PathBuf;
+
+#[derive(Clone, Debug)]
+pub enum Interface {
+    Dead { linktype: i32, snaplen: i32 },
+    Live(String),
+    Lookup,
+    File(PathBuf),
+}
 
 #[derive(Clone, Debug)]
 pub struct Config {
+    interface: Interface,
     max_packets_read: usize,
     snaplen: u32,
     buffer_size: u32,
+    datalink: Option<i32>,
     bpf: Option<String>,
     buffer_for: std::time::Duration,
     blocking: bool,
 }
 
 impl Config {
+    pub fn interface(&self) -> &Interface {
+        &self.interface
+    }
+
+    pub fn with_interface(&mut self, iface: Interface) -> &mut Self {
+        self.interface = iface;
+        self
+    }
+
     pub fn max_packets_read(&self) -> usize {
         self.max_packets_read
     }
@@ -26,6 +46,15 @@ impl Config {
 
     pub fn with_snaplen(&mut self, amt: u32) -> &mut Self {
         self.snaplen = amt;
+        self
+    }
+
+    pub fn datalink(&self) -> &Option<i32> {
+        &self.datalink
+    }
+
+    pub fn with_datalink_type(&mut self, datalink: i32) -> &mut Self {
+        self.datalink = Some(datalink);
         self
     }
 
@@ -64,32 +93,16 @@ impl Config {
         self.blocking = blocking;
         self
     }
-
-    pub fn new(
-        max_packets_read: usize,
-        snaplen: u32,
-        buffer_size: u32,
-        bpf: Option<String>,
-        buffer_for: std::time::Duration,
-        blocking: bool,
-    ) -> Config {
-        Config {
-            max_packets_read,
-            snaplen,
-            buffer_size,
-            bpf,
-            buffer_for,
-            blocking,
-        }
-    }
 }
 
 impl Default for Config {
     fn default() -> Config {
         Config {
+            interface: Interface::Lookup,
             max_packets_read: 1000,
             snaplen: 65535,
             buffer_size: 16777216,
+            datalink: None,
             bpf: None,
             buffer_for: std::time::Duration::from_millis(100),
             blocking: false,

--- a/src/handle.rs
+++ b/src/handle.rs
@@ -1,29 +1,46 @@
 use crate::bpf::Bpf;
-use crate::{errors::Error, pcap_util, stats::Stats};
+use crate::{pcap_util, stats::Stats, Config, Error, Interface, PacketStream};
 use log::*;
 use pcap_sys::{pcap_fileno, pcap_set_immediate_mode};
 use std::os::raw::c_int;
 use std::path::Path;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+
+fn compile_bpf(handle: *mut pcap_sys::pcap_t, bpf: &str) -> Result<Bpf, Error> {
+    let mut bpf_program = pcap_sys::bpf_program {
+        bf_len: 0,
+        bf_insns: std::ptr::null_mut(),
+    };
+
+    let bpf_str = std::ffi::CString::new(bpf).map_err(Error::Ffi)?;
+
+    if 0 != unsafe {
+        pcap_sys::pcap_compile(
+            handle,
+            &mut bpf_program,
+            bpf_str.as_ptr(),
+            1,
+            pcap_sys::PCAP_NETMASK_UNKNOWN,
+        )
+    } {
+        return Err(pcap_util::convert_libpcap_error(handle));
+    }
+
+    Ok(Bpf::new(bpf_program))
+}
 
 /// Wrapper around a pcap_t handle to indicate live or offline capture, and allow the handle to
 /// be interrupted to stop capture.
 #[derive(Clone)]
-pub struct Handle {
+pub struct PendingHandle {
     handle: *mut pcap_sys::pcap_t,
     live_capture: bool,
-    interrupted: std::sync::Arc<std::sync::Mutex<bool>>,
 }
 
-unsafe impl Send for Handle {}
-unsafe impl Sync for Handle {}
-
-impl Handle {
-    pub fn is_live_capture(&self) -> bool {
-        self.live_capture
-    }
-
+impl PendingHandle {
     /// Create a live capture from a string representing an interface
-    pub fn live_capture(iface: &str) -> Result<std::sync::Arc<Handle>, Error> {
+    pub fn live_capture(iface: &str) -> Result<PendingHandle, Error> {
         let device_str = std::ffi::CString::new(iface).map_err(Error::Ffi)?;
 
         let errbuf = ([0 as std::os::raw::c_char; 256]).as_mut_ptr();
@@ -38,11 +55,10 @@ impl Handle {
             })
         } else {
             info!("Live stream created for interface {}", iface);
-            let handle = std::sync::Arc::new(Handle {
+            let handle = PendingHandle {
                 handle: h,
                 live_capture: true,
-                interrupted: std::sync::Arc::new(std::sync::Mutex::new(false)),
-            });
+            };
             Ok(handle)
         };
         drop(errbuf);
@@ -50,7 +66,7 @@ impl Handle {
     }
 
     /// Create an offline capture from a path to a file
-    pub fn file_capture<P: AsRef<Path>>(path: P) -> Result<std::sync::Arc<Handle>, Error> {
+    pub fn file_capture<P: AsRef<Path>>(path: P) -> Result<PendingHandle, Error> {
         let path = if let Some(s) = path.as_ref().to_str() {
             s
         } else {
@@ -70,11 +86,10 @@ impl Handle {
             })
         } else {
             info!("File stream created for file {}", path);
-            let handle = std::sync::Arc::new(Handle {
+            let handle = PendingHandle {
                 handle: h,
                 live_capture: false,
-                interrupted: std::sync::Arc::new(std::sync::Mutex::new(false)),
-            });
+            };
             Ok(handle)
         };
         drop(errbuf);
@@ -82,23 +97,23 @@ impl Handle {
     }
 
     /// Create a dead handle, typically used for compiling bpf's
-    pub fn dead(linktype: i32, snaplen: i32) -> Result<std::sync::Arc<Handle>, Error> {
+    pub fn dead(linktype: i32, snaplen: i32) -> Result<PendingHandle, Error> {
         let h = unsafe { pcap_sys::pcap_open_dead(linktype as c_int, snaplen as c_int) };
         if h.is_null() {
             error!("Failed to create dead handle");
             Err(Error::Custom("Could not create dead handle".to_owned()))
         } else {
             info!("Dead handle created");
-            let handle = std::sync::Arc::new(Handle {
+            let handle = PendingHandle {
                 handle: h,
                 live_capture: false,
-                interrupted: std::sync::Arc::new(std::sync::Mutex::new(false)),
-            });
+            };
             Ok(handle)
         }
     }
 
-    pub fn lookup() -> Result<std::sync::Arc<Handle>, Error> {
+    /// Create a handle by lookup of devices
+    pub fn lookup() -> Result<PendingHandle, Error> {
         let errbuf = ([0 as std::os::raw::c_char; 256]).as_mut_ptr();
         let dev = unsafe { pcap_sys::pcap_lookupdev(errbuf) };
         let res = if dev.is_null() {
@@ -106,14 +121,166 @@ impl Handle {
         } else {
             pcap_util::cstr_to_string(dev as _).and_then(|s| {
                 debug!("Lookup found interface {}", s);
-                Handle::live_capture(&s)
+                PendingHandle::live_capture(&s)
             })
         };
         drop(errbuf);
         res
     }
 
-    pub fn set_non_block(&self) -> Result<&Self, Error> {
+    pub fn set_promiscuous(self) -> Result<Self, Error> {
+        if 0 != unsafe { pcap_sys::pcap_set_promisc(self.handle, 1) } {
+            Err(pcap_util::convert_libpcap_error(self.handle))
+        } else {
+            Ok(self)
+        }
+    }
+
+    pub fn set_snaplen(self, snaplen: u32) -> Result<Self, Error> {
+        if 0 != unsafe { pcap_sys::pcap_set_snaplen(self.handle, snaplen as _) } {
+            Err(pcap_util::convert_libpcap_error(self.handle))
+        } else {
+            Ok(self)
+        }
+    }
+
+    pub fn set_timeout(self, dur: &std::time::Duration) -> Result<Self, Error> {
+        if 0 != unsafe { pcap_sys::pcap_set_timeout(self.handle, dur.as_millis() as _) } {
+            Err(pcap_util::convert_libpcap_error(self.handle))
+        } else {
+            Ok(self)
+        }
+    }
+
+    pub fn set_buffer_size(self, buffer_size: u32) -> Result<Self, Error> {
+        if 0 != unsafe { pcap_sys::pcap_set_buffer_size(self.handle, buffer_size as _) } {
+            Err(pcap_util::convert_libpcap_error(self.handle))
+        } else {
+            Ok(self)
+        }
+    }
+
+    pub fn set_datalink(&self, datalink: i32) -> Result<&Self, Error> {
+        if 0 != unsafe { pcap_sys::pcap_set_datalink(self.handle, datalink as _) } {
+            Err(pcap_util::convert_libpcap_error(self.handle))
+        } else {
+            Ok(self)
+        }
+    }
+
+    pub fn get_datalink(&self) -> Result<i32, Error> {
+        let r = unsafe { pcap_sys::pcap_datalink(self.handle) };
+        if r < 0 {
+            Err(pcap_util::convert_libpcap_error(self.handle))
+        } else {
+            Ok(r)
+        }
+    }
+
+    pub fn set_immediate_mode(self) -> Result<Self, Error> {
+        if 0 != unsafe { pcap_sys::pcap_set_immediate_mode(self.handle, 1) } {
+            Err(pcap_util::convert_libpcap_error(self.handle))
+        } else {
+            Ok(self)
+        }
+    }
+
+    pub fn activate(self) -> Result<Handle, Error> {
+        let h = Handle {
+            handle: self.handle,
+            live_capture: self.live_capture,
+            interrupted: Arc::new(AtomicBool::new(false)),
+        };
+        if self.live_capture {
+            if 0 != unsafe { pcap_sys::pcap_activate(h.handle) } {
+                return Err(pcap_util::convert_libpcap_error(h.handle));
+            }
+        }
+        Ok(h)
+    }
+}
+
+impl std::convert::TryFrom<&Config> for PendingHandle {
+    type Error = Error;
+
+    fn try_from(v: &Config) -> Result<Self, Self::Error> {
+        let mut pending = match v.interface() {
+            Interface::Dead { linktype, snaplen } => PendingHandle::dead(*linktype, *snaplen)?,
+            Interface::Lookup => PendingHandle::lookup()?,
+            Interface::File(path) => PendingHandle::file_capture(path)?,
+            Interface::Live(dev) => PendingHandle::live_capture(dev)?,
+        };
+
+        if pending.live_capture {
+            pending = pending
+                .set_snaplen(v.snaplen())?
+                .set_promiscuous()?
+                .set_buffer_size(v.buffer_size())?;
+        }
+
+        Ok(pending)
+    }
+}
+
+/// Wrapper around a pcap_t handle to indicate live or offline capture, and allow the handle to
+/// be interrupted to stop capture.
+#[derive(Clone)]
+pub struct Handle {
+    handle: *mut pcap_sys::pcap_t,
+    live_capture: bool,
+    interrupted: Arc<AtomicBool>,
+}
+
+unsafe impl Send for Handle {}
+unsafe impl Sync for Handle {}
+
+impl Handle {
+    pub fn is_live_capture(&self) -> bool {
+        self.live_capture
+    }
+
+    /// Create a live capture from a string representing an interface
+    pub fn live_capture(iface: &str) -> Result<Handle, Error> {
+        PendingHandle::live_capture(iface)?.activate()
+    }
+
+    /// Create an offline capture from a path to a file
+    pub fn file_capture<P: AsRef<Path>>(path: P) -> Result<Handle, Error> {
+        PendingHandle::file_capture(path)?.activate()
+    }
+
+    /// Create a dead handle, typically used for compiling bpf's
+    pub fn dead(linktype: i32, snaplen: i32) -> Result<Handle, Error> {
+        PendingHandle::dead(linktype, snaplen)?.activate()
+    }
+
+    /// Create a handle by lookup of devices
+    pub fn lookup() -> Result<Handle, Error> {
+        PendingHandle::lookup()?.activate()
+    }
+
+    pub fn interrupted(&self) -> bool {
+        self.interrupted.load(Ordering::Relaxed)
+    }
+
+    pub fn interrupt(&self) {
+        let interrupted = self.interrupted.swap(true, Ordering::Relaxed);
+        if !interrupted {
+            unsafe {
+                pcap_sys::pcap_breakloop(self.handle);
+            }
+        }
+    }
+
+    pub fn set_bpf(self, mut bpf: Bpf) -> Result<Self, Error> {
+        let ret_code = unsafe { pcap_sys::pcap_setfilter(self.handle, bpf.inner_mut()) };
+        if ret_code != 0 {
+            return Err(pcap_util::convert_libpcap_error(self.handle));
+        }
+        Ok(self)
+    }
+
+    pub fn set_non_block(self) -> Result<Self, Error> {
         let errbuf = ([0 as std::os::raw::c_char; 256]).as_mut_ptr();
         if -1 == unsafe { pcap_sys::pcap_setnonblock(self.handle, 1, errbuf) } {
             pcap_util::cstr_to_string(errbuf as _).and_then(|msg| {
@@ -125,81 +292,8 @@ impl Handle {
         }
     }
 
-    pub fn set_promiscuous(&self) -> Result<&Self, Error> {
-        if 0 != unsafe { pcap_sys::pcap_set_promisc(self.handle, 1) } {
-            Err(pcap_util::convert_libpcap_error(self.handle))
-        } else {
-            Ok(self)
-        }
-    }
-
-    pub fn set_snaplen(&self, snaplen: u32) -> Result<&Self, Error> {
-        if 0 != unsafe { pcap_sys::pcap_set_snaplen(self.handle, snaplen as _) } {
-            Err(pcap_util::convert_libpcap_error(self.handle))
-        } else {
-            Ok(self)
-        }
-    }
-
-    pub fn set_timeout(&self, dur: &std::time::Duration) -> Result<&Self, Error> {
-        if 0 != unsafe { pcap_sys::pcap_set_timeout(self.handle, dur.as_millis() as _) } {
-            Err(pcap_util::convert_libpcap_error(self.handle))
-        } else {
-            Ok(self)
-        }
-    }
-
-    pub fn set_buffer_size(&self, buffer_size: u32) -> Result<&Self, Error> {
-        if 0 != unsafe { pcap_sys::pcap_set_buffer_size(self.handle, buffer_size as _) } {
-            Err(pcap_util::convert_libpcap_error(self.handle))
-        } else {
-            Ok(self)
-        }
-    }
-
-    pub fn compile_bpf(&self, bpf: &str) -> Result<Bpf, Error> {
-        let mut bpf_program = pcap_sys::bpf_program {
-            bf_len: 0,
-            bf_insns: std::ptr::null_mut(),
-        };
-
-        let bpf_str = std::ffi::CString::new(bpf.clone()).map_err(Error::Ffi)?;
-
-        if 0 != unsafe {
-            pcap_sys::pcap_compile(
-                self.handle,
-                &mut bpf_program,
-                bpf_str.as_ptr(),
-                1,
-                pcap_sys::PCAP_NETMASK_UNKNOWN,
-            )
-        } {
-            return Err(pcap_util::convert_libpcap_error(self.handle));
-        }
-
-        Ok(Bpf::new(bpf_program))
-    }
-
-    pub fn set_bpf(&self, bpf: Bpf) -> Result<&Self, Error> {
-        let mut bpf = bpf;
-
-        let ret_code = unsafe { pcap_sys::pcap_setfilter(self.handle, bpf.inner_mut()) };
-        if ret_code != 0 {
-            return Err(pcap_util::convert_libpcap_error(self.handle));
-        }
-        Ok(self)
-    }
-
-    pub fn set_immediate_mode(&self) -> Result<&Self, Error> {
-        if 0 != unsafe { pcap_sys::pcap_set_immediate_mode(self.handle, 1) } {
-            Err(pcap_util::convert_libpcap_error(self.handle))
-        } else {
-            Ok(self)
-        }
-    }
-
-    pub fn activate(&self) -> Result<&Self, Error> {
-        if 0 != unsafe { pcap_sys::pcap_activate(self.handle) } {
+    pub fn set_datalink(self, datalink: i32) -> Result<Self, Error> {
+        if 0 != unsafe { pcap_sys::pcap_set_datalink(self.handle, datalink as _) } {
             Err(pcap_util::convert_libpcap_error(self.handle))
         } else {
             Ok(self)
@@ -217,28 +311,8 @@ impl Handle {
         }
     }
 
-    pub fn as_mut_ptr(&self) -> *mut pcap_sys::pcap_t {
-        self.handle
-    }
-
-    pub fn interrupted(&self) -> bool {
-        self.interrupted.lock().map(|l| *l).unwrap_or(true)
-    }
-
-    pub fn interrupt(&self) {
-        let interrupted = self
-            .interrupted
-            .lock()
-            .map(|mut l| {
-                *l = true;
-                false
-            })
-            .unwrap_or(true);
-        if !interrupted {
-            unsafe {
-                pcap_sys::pcap_breakloop(self.handle);
-            }
-        }
+    pub fn compile_bpf(&self, bpf: &str) -> Result<Bpf, Error> {
+        compile_bpf(self.handle, bpf)
     }
 
     pub fn stats(&self) -> Result<Stats, Error> {
@@ -262,6 +336,14 @@ impl Handle {
     pub fn close(&self) {
         unsafe { pcap_sys::pcap_close(self.handle) }
     }
+
+    pub fn into_stream(self, cfg: Config) -> PacketStream {
+        PacketStream::new(cfg, self)
+    }
+
+    pub(crate) fn as_mut_ptr(&self) -> *mut pcap_sys::pcap_t {
+        self.handle
+    }
 }
 
 impl Drop for Handle {
@@ -270,10 +352,29 @@ impl Drop for Handle {
     }
 }
 
+impl std::convert::TryFrom<&Config> for Handle {
+    type Error = Error;
+
+    fn try_from(v: &Config) -> Result<Self, Self::Error> {
+        let mut handle = PendingHandle::try_from(v)?.activate()?;
+
+        if let Some(datalink) = v.datalink() {
+            handle = handle.set_datalink(*datalink)?;
+        }
+        if handle.live_capture && !v.blocking() {
+            handle = handle.set_non_block()?;
+        }
+        if let Some(bpf) = v.bpf() {
+            let bpf = handle.compile_bpf(bpf)?;
+            handle = handle.set_bpf(bpf)?;
+        }
+
+        Ok(handle)
+    }
+}
+
 #[cfg(test)]
 mod tests {
-    extern crate env_logger;
-
     use super::*;
     use std::path::PathBuf;
 
@@ -297,6 +398,7 @@ mod tests {
 
         assert!(handle.is_ok());
     }
+
     #[test]
     fn open_dead() {
         let _ = env_logger::try_init();
@@ -305,6 +407,20 @@ mod tests {
 
         assert!(handle.is_ok());
     }
+
+    #[test]
+    fn set_datalink() {
+        let _ = env_logger::try_init();
+
+        let handle = Handle::dead(0, 0).unwrap();
+
+        let r = handle.set_datalink(108);
+
+        assert!(r.is_err());
+
+        assert!(format!("{:?}", r.err().unwrap()).contains("not one of the DLTs supported"));
+    }
+
     #[test]
     fn bpf_compile() {
         let _ = env_logger::try_init();

--- a/src/handle.rs
+++ b/src/handle.rs
@@ -185,6 +185,14 @@ impl PendingHandle {
         }
     }
 
+    pub fn set_rfmon(self) -> Result<Self, Error> {
+        if 0 != unsafe { pcap_sys::pcap_set_rfmon(self.handle, 1) } {
+            Err(pcap_util::convert_libpcap_error(self.handle))
+        } else {
+            Ok(self)
+        }
+    }
+
     pub fn activate(self) -> Result<Handle, Error> {
         let h = Handle {
             handle: self.handle,
@@ -216,6 +224,9 @@ impl std::convert::TryFrom<&Config> for PendingHandle {
                 .set_snaplen(v.snaplen())?
                 .set_promiscuous()?
                 .set_buffer_size(v.buffer_size())?;
+            if v.rfmon() {
+                pending = pending.set_rfmon()?;
+            }
         }
 
         Ok(pending)


### PR DESCRIPTION
Provide a builder style api for creating pending handles, then activating them.
Config now supports specifying interface to simplify creation, and a stream can
be created from a config without needing to first create a handle.