### PR TITLE
Depending directly on blocking (which smol exports) rather than pulli…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ Cargo.lock
 .idea
 target
 *.a
+.vscode

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ repository = "https://github.com/dbcfd/pcap-async"
 exclude = ["resources/*.pcap"]
 
 [dependencies]
+blocking = "1.0.0"
 byteorder = "1.3"
 futures = "0.3"
 libc = "0.2"
@@ -26,7 +27,6 @@ log = "0.4"
 mio = "0.6"
 pin-project = "0.4"
 pcap-sys = "0.1"
-smol = "1.2"
 thiserror = "1.0"
 
 [dev-dependencies]

--- a/src/bridge_stream.rs
+++ b/src/bridge_stream.rs
@@ -325,7 +325,7 @@ mod tests {
         let packet_provider = BridgeStream::new(vec![packet_stream], Duration::from_millis(100), 2)
             .expect("Failed to build");
 
-        let packets = smol::block_on(async move {
+        let packets = futures::executor::block_on(async move {
             let fut_packets = packet_provider.collect::<Vec<_>>();
             let packets: Vec<_> = fut_packets
                 .await
@@ -382,7 +382,7 @@ mod tests {
         let packet_provider = BridgeStream::new(vec![packet_stream], Duration::from_millis(100), 2)
             .expect("Failed to build");
 
-        let packets = smol::block_on(async move {
+        let packets = futures::executor::block_on(async move {
             let fut_packets = async move {
                 let mut packet_provider = packet_provider.boxed();
                 let mut packets = vec![];
@@ -419,7 +419,8 @@ mod tests {
 
         assert!(
             stream.is_ok(),
-            format!("Could not build stream {}", stream.err().unwrap())
+            "Could not build stream {}",
+            stream.err().unwrap()
         );
     }
 
@@ -440,7 +441,8 @@ mod tests {
 
         assert!(
             stream.is_ok(),
-            format!("Could not build stream {}", stream.err().unwrap())
+            "Could not build stream {}",
+            stream.err().unwrap()
         );
     }
 
@@ -469,7 +471,7 @@ mod tests {
         let stream1 = futures::stream::iter(vec![item1]);
         let stream2 = futures::stream::iter(vec![item2]);
 
-        let result = smol::block_on(async move {
+        let result = futures::executor::block_on(async move {
             let bridge = BridgeStream::new(vec![stream1, stream2], Duration::from_millis(100), 0);
 
             let result = bridge

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,7 +64,7 @@ mod tests {
         let mut cfg = Config::default();
         cfg.with_max_packets_read(5000);
 
-        let packets = smol::block_on(async move {
+        let packets = futures::executor::block_on(async move {
             let packet_provider =
                 PacketStream::new(Config::default(), std::sync::Arc::clone(&handle))
                     .expect("Failed to build");

--- a/src/packet/future.rs
+++ b/src/packet/future.rs
@@ -77,7 +77,7 @@ impl DispatchArgs {
     async fn poll(&self, timeout: Option<Duration>) -> Result<InterfaceReady, Error> {
         trace!("Polling FD with timeout {:?}", timeout);
         let fd = self.fd.clone();
-        smol::unblock(move || poll_ready(fd, timeout)).await
+        blocking::unblock(move || poll_ready(fd, timeout)).await
     }
 }
 

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -117,7 +117,7 @@ mod tests {
         let handle = Handle::file_capture(pcap_path.to_str().expect("No path found"))
             .expect("No handle created");
 
-        let packets = smol::block_on(async move {
+        let packets = futures::executor::block_on(async move {
             let packet_provider =
                 PacketStream::new(Config::default(), Arc::clone(&handle)).expect("Failed to build");
             let fut_packets = packet_provider.collect::<Vec<_>>();
@@ -170,7 +170,7 @@ mod tests {
         let handle = Handle::file_capture(pcap_path.to_str().expect("No path found"))
             .expect("No handle created");
 
-        let packets = smol::block_on(async move {
+        let packets = futures::executor::block_on(async move {
             let packet_provider =
                 PacketStream::new(Config::default(), Arc::clone(&handle)).expect("Failed to build");
             let fut_packets = packet_provider.collect::<Vec<_>>();
@@ -200,7 +200,7 @@ mod tests {
 
         info!("Testing against {:?}", pcap_path);
 
-        let packets = smol::block_on(async move {
+        let packets = futures::executor::block_on(async move {
             let handle = Handle::file_capture(pcap_path.to_str().expect("No path found"))
                 .expect("No handle created");
 
@@ -239,12 +239,13 @@ mod tests {
 
         assert!(
             stream.is_ok(),
-            format!("Could not build stream {}", stream.err().unwrap())
+            "Could not build stream {}",
+            stream.err().unwrap()
         );
 
         let mut stream = stream.unwrap();
 
-        smol::block_on(async move { stream.next().await })
+        futures::executor::block_on(async move { stream.next().await })
             .unwrap()
             .unwrap();
     }
@@ -264,7 +265,8 @@ mod tests {
 
         assert!(
             stream.is_ok(),
-            format!("Could not build stream {}", stream.err().unwrap())
+            "Could not build stream {}",
+            stream.err().unwrap()
         );
     }
 }


### PR DESCRIPTION
…ng in all of smol